### PR TITLE
ADD: reward preface text setting for daily note saves

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -292,7 +292,7 @@ export default class ObsidianRewarder extends Plugin {
 
     let logRewardsText =
       (this.settings.saveRewardToDaily && logTaskOnly === false
-        ? "Earned reward: " +
+        ? this.settings.rewardPreface +
           chosenReward.rewardName
         : "");
 

--- a/settings.ts
+++ b/settings.ts
@@ -24,6 +24,7 @@ export interface ObsidianRewarderSettings {
   saveTaskSectionHeading?: string;
   showModal: boolean;
   useAsInspirational: boolean;
+  rewardPreface: string;
 }
 
 export const DEFAULT_SETTINGS: ObsidianRewarderSettings = {
@@ -42,6 +43,7 @@ export const DEFAULT_SETTINGS: ObsidianRewarderSettings = {
   saveTaskSectionHeading: undefined,
   showModal: true,
   useAsInspirational: false,
+  rewardPreface: "- [ ] Earned reward: ",
 };
 
 import ObsidianRewarder from "./main"
@@ -141,6 +143,29 @@ export class ObsidianRewarderSettingsTab extends PluginSettingTab {
             this.display();
           })
       );
+
+    new Setting(containerEl)
+    .setName("Reward preface text")
+    .setDesc("The text that appears before each reward in the daily note")
+    .addText((text) =>
+      text
+        .setPlaceholder("- [ ] Earned reward: ")
+        .setValue(this.plugin.settings.rewardPreface)
+        .onChange(async (value) => {
+          this.plugin.settings.rewardPreface = value;
+          await this.plugin.saveSettings();
+        })
+    )
+    .addExtraButton((button) =>
+      button
+        .setIcon("reset")
+        .setTooltip("Restore default")
+        .onClick(async () => {
+          this.plugin.settings.rewardPreface = DEFAULT_SETTINGS.rewardPreface;
+          await this.plugin.saveSettings();
+          this.display();
+        })
+    );
 
     new Setting(this.containerEl)
       .setName("Save task in daily note")


### PR DESCRIPTION
This allows for the user to customize how the reward shows up in the bottom of the daily note. For instance, I like to have it with a checkbox in front of it so that I can check off the rewards as I reward myself with them.